### PR TITLE
Fix 2D Means Detach

### DIFF
--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -562,7 +562,7 @@ def rasterization(
     if compensations is not None:
         opacities = opacities * compensations
 
-    if with_geer and with_eval3d:
+    if with_eval3d:
         means2d = means2d.detach()
 
     meta.update(


### PR DESCRIPTION
Small bug fix: Have `means2d` detach for any use of `with_eval3d`, not just 3DGEER.